### PR TITLE
removed session proposal sections

### DIFF
--- a/diversity.md
+++ b/diversity.md
@@ -8,9 +8,6 @@ This is an ongoing process. We are talking amongst our event organizers, and var
 
 Here are some ways you can help us build a more diverse conference experience:
 
-* Recommend appropriate speakers and/or organizers to the current organizers (see [our call for session proposals](http://vtcodecamp.org/#speak); you may also send an email to [team@vtcodecamp.org](mailto:team@vtcodecamp.org).
-* Forward our call for proposals to relevant affinity groups with the message that we are looking for a diverse speaker roster.
-* Suggest to potential speakers that they submit a proposal during our call for session proposals phase (see [our call for session proposals](http://vtcodecamp.org/#speak) for details).
 * Organize community-based public speaking trainings and practice events (Ignite is one popular format).
 * Suggest ways that the onsite event experience can be more welcoming and supportive, free from intimidation and marginalization (send an email to [team@vtcodecamp.org](mailto:team@vtcodecamp.org)).
 * Share your ideas and best practices for how we can realize our vision (send an email to [team@vtcodecamp.org](mailto:team@vtcodecamp.org)).


### PR DESCRIPTION
The due date for session proposal submissions have passed so that section seemed misleading (because it's too late for someone to spread the word about CFPs to diverse communities for 2016.) But would be important to remember to add that back in for 2017 in time for that to happen!
